### PR TITLE
Allow multiple algorithms for app

### DIFF
--- a/src/algorithms/graham_scan.rs
+++ b/src/algorithms/graham_scan.rs
@@ -167,8 +167,16 @@ impl GrahamScan {
 }
 
 impl Algorithm for GrahamScan {
-    fn get_points(&self) -> Vec<Point2<f64>> {
-        self.points.clone()
+    fn get_title(&self) -> &str {
+        "Graham scan"
+    }
+
+    fn get_points(&self) -> &Vec<Point2<f64>> {
+        &self.points
+    }
+
+    fn set_points(&mut self, points: Vec<Point2<f64>>) {
+        self.points = points;
     }
 
     fn get_steps(&self) -> Vec<Vec<Line>> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,46 +3,60 @@ use crossterm::event::{KeyCode, KeyEvent};
 use nalgebra::Point2;
 use rand::Rng;
 
-use crate::algorithms::graham_scan::GrahamScan;
+use crate::algorithms::{algorithm::AlgorithmWrapper, graham_scan::GrahamScan};
 
 pub enum InputMode {
     Normal,
     Editing,
 }
 
-pub struct TabsState<'a> {
-    pub titles: Vec<&'a str>,
+pub struct TabsState {
+    pub tabs: Vec<Tab>,
     pub index: usize,
 }
 
-impl<'a> TabsState<'a> {
-    pub fn new(titles: Vec<&'a str>) -> TabsState {
-        TabsState { titles, index: 0 }
+pub struct Tab {
+    pub algorithm: AlgorithmWrapper,
+    pub step: usize,
+    pub max_steps: Option<usize>,
+    pub point_amount: Option<usize>,
+}
+
+impl Tab {
+    fn new(algorithm: AlgorithmWrapper) -> Self {
+        Tab {
+            algorithm,
+            step: 0,
+            max_steps: None,
+            point_amount: None,
+        }
     }
+}
+
+impl TabsState {
+    pub fn new(tabs: Vec<Tab>) -> TabsState {
+        TabsState { tabs, index: 0 }
+    }
+
     pub fn next(&mut self) {
-        self.index = (self.index + 1) % self.titles.len();
+        self.index = (self.index + 1) % self.tabs.len();
     }
 
     pub fn previous(&mut self) {
         if self.index > 0 {
             self.index -= 1;
         } else {
-            self.index = self.titles.len() - 1;
+            self.index = self.tabs.len() - 1;
         }
     }
 }
 
 pub struct App<'a> {
     pub title: &'a str,
-    pub tabs: TabsState<'a>,
+    pub tab_state: TabsState,
 
     pub input_mode: InputMode,
     pub input: String,
-
-    pub algorithm: GrahamScan,
-    pub step: usize,
-    pub max_steps: Option<usize>,
-    pub point_amount: Option<usize>,
 
     pub x_bounds: [f64; 2],
     pub y_bounds: [f64; 2],
@@ -54,17 +68,36 @@ impl<'a> App<'a> {
     pub fn new(title: &'a str, x_bounds: [f64; 2], y_bounds: [f64; 2]) -> App<'a> {
         App {
             title,
-            tabs: TabsState::new(vec!["Graham Scan", "Another algorithm"]),
+            tab_state: TabsState::new(vec![
+                Tab::new(AlgorithmWrapper::GrahamScan(GrahamScan::new())),
+                Tab::new(AlgorithmWrapper::GrahamScan(GrahamScan::new())),
+            ]),
             input_mode: InputMode::Normal,
             input: String::new(),
-            algorithm: GrahamScan::new(),
-            step: 0,
-            max_steps: None,
-            point_amount: None,
             x_bounds,
             y_bounds,
             should_quit: false,
         }
+    }
+
+    pub fn get_current_tab(&self) -> &Tab {
+        if let Some(tab) = &self.tab_state.tabs.get(self.tab_state.index) {
+            return tab;
+        }
+        self.tab_state
+            .tabs
+            .get(0)
+            .expect("The application has no tabs open.")
+    }
+
+    pub fn get_current_tab_mut(&mut self) -> &mut Tab {
+        &mut self.tab_state.tabs[self.tab_state.index]
+    }
+
+    pub fn reset_tab(&mut self) -> Result<(), Error> {
+        self.get_current_tab_mut().step = 0;
+        self.get_current_tab_mut().point_amount = Some(self.input.parse::<usize>()?);
+        Ok(())
     }
 
     /// Generates points in random locations bounded by the App structs bounds and
@@ -72,7 +105,7 @@ impl<'a> App<'a> {
     fn generate_points(&mut self) {
         let mut points = vec![];
 
-        if let Some(point_amount) = self.point_amount {
+        if let Some(point_amount) = self.get_current_tab().point_amount {
             for _ in 0..point_amount {
                 let x = rand::thread_rng().gen_range(self.x_bounds[0]..=self.x_bounds[1]);
                 let y = rand::thread_rng().gen_range(self.y_bounds[0]..=self.y_bounds[1]);
@@ -80,28 +113,36 @@ impl<'a> App<'a> {
                 points.push(point);
             }
         }
-        self.algorithm.points = points;
+        self.get_current_tab_mut().algorithm.set_points(points);
+    }
+
+    pub fn setup_tab(&mut self) {
+        self.get_current_tab_mut().algorithm.calculate();
+        self.get_current_tab_mut().max_steps =
+            Some(self.get_current_tab().algorithm.get_maximum_step_count());
     }
 
     pub fn on_key(&mut self, key: KeyEvent) -> Result<(), Error> {
         match key.code {
             KeyCode::Right => {
-                if let Some(max_steps) = self.max_steps {
-                    if self.step < max_steps - 1 {
-                        self.step += 1;
+                let tab = self.get_current_tab_mut();
+                if let Some(max_steps) = tab.max_steps {
+                    if tab.step < max_steps - 1 {
+                        tab.step += 1;
                     }
                 }
             }
             KeyCode::Left => {
-                if self.step > 0 {
-                    self.step -= 1;
+                let tab = self.get_current_tab_mut();
+                if tab.step > 0 {
+                    tab.step -= 1;
                 }
             }
             KeyCode::Tab => {
-                self.tabs.next();
+                self.tab_state.next();
             }
             KeyCode::BackTab => {
-                self.tabs.previous();
+                self.tab_state.previous();
             }
             _ => {}
         }
@@ -117,11 +158,9 @@ impl<'a> App<'a> {
             },
             InputMode::Editing => match key.code {
                 KeyCode::Enter => {
-                    self.step = 0;
-                    self.point_amount = Some(self.input.parse::<usize>()?);
+                    self.reset_tab()?;
                     self.generate_points();
-                    self.algorithm.calculate();
-                    self.max_steps = Some(self.algorithm.maximum_step_count);
+                    self.setup_tab();
                 }
                 KeyCode::Char(c) => {
                     if c.is_ascii_digit() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -33,7 +33,7 @@ pub fn draw<B: Backend>(f: &mut Frame<B>, app: &App) {
             let title = match &tab.algorithm {
                 AlgorithmWrapper::GrahamScan(algorithm) => Spans::from(Span::styled(
                     algorithm.get_title(),
-                    Style::default().fg(Color::Green),
+                    Style::default().fg(Color::Gray),
                 )),
             };
             title

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -8,8 +8,8 @@ use tui::{
 };
 
 use crate::{
-    algorithms::algorithm::Algorithm,
-    app::{App, InputMode},
+    algorithms::algorithm::{Algorithm, AlgorithmWrapper},
+    app::{App, InputMode, Tab},
 };
 
 pub fn draw<B: Backend>(f: &mut Frame<B>, app: &App) {
@@ -24,24 +24,33 @@ pub fn draw<B: Backend>(f: &mut Frame<B>, app: &App) {
             .as_ref(),
         )
         .split(f.size());
+
     let titles = app
+        .tab_state
         .tabs
-        .titles
         .iter()
-        .map(|t| Spans::from(Span::styled(*t, Style::default().fg(Color::Green))))
+        .map(|tab| {
+            let title = match &tab.algorithm {
+                AlgorithmWrapper::GrahamScan(algorithm) => Spans::from(Span::styled(
+                    algorithm.get_title(),
+                    Style::default().fg(Color::Green),
+                )),
+            };
+            title
+        })
         .collect();
+
     let tabs = Tabs::new(titles)
         .block(Block::default().borders(Borders::ALL).title(app.title))
         .highlight_style(Style::default().fg(Color::Yellow))
-        .select(app.tabs.index);
+        .select(app.tab_state.index);
     f.render_widget(tabs, chunks[0]);
+
     draw_header(f, chunks[1]);
 
-    match app.tabs.index {
-        0 => app.algorithm.draw_algorithm(f, chunks[2], app),
-        _ => {}
-    }
-    draw_footer(f, chunks[3], app);
+    app.get_current_tab().algorithm.draw(f, chunks[2], app);
+
+    draw_footer(f, chunks[3], app, app.get_current_tab());
 }
 
 fn draw_header<B>(f: &mut Frame<B>, area: Rect)
@@ -58,7 +67,7 @@ where
     f.render_widget(paragraph, area);
 }
 
-fn draw_footer<B>(f: &mut Frame<B>, area: Rect, app: &App)
+fn draw_footer<B>(f: &mut Frame<B>, area: Rect, app: &App, _tab: &Tab)
 where
     B: Backend,
 {


### PR DESCRIPTION
This PR resolves #5 and uses the new tab structure and adds the algorithm state to a tab respectively. Right now the app allows only one algorithm to be rendered. With the previous change the app can manage multiple tabs which will then manage a whole algorithm each.